### PR TITLE
feat: support altnernate remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ cd ~/code/src/github.com/mcwarman/gitscripts
 
 ### `dependabot-merge`
 
-Creates a branch `dependabot-merge`, then attempts to rebase and merge all branches `origin/dependabot/...` into it.
+Creates a branch `dependabot-merge`, then attempts to rebase and merge all branches `origin/dependabot/...` into it. If origin isn't your remote, then you can specify that using `-r`.
+
+```shell
+$ git dependabot-merge -r github
+Working on dependabot/github_actions/pascalgn/automerge-action-0.15.5
+Switched to a new branch 'dependabot/github_actions/pascalgn/automerge-action-0.15.5'
+```
 
 ### `gone`
 

--- a/src/git-dependabot-merge
+++ b/src/git-dependabot-merge
@@ -1,21 +1,46 @@
 #!/usr/bin/env bash
 set -eu
 
+usage() {
+  printf 'usage: git dependabot-merge [-r <remote>]
+OPTIONS
+  -r  Set the remote to check [default: origin]
+
+EXAMPLES
+git dependabot-merge -r github
+git dependabot-merge
+'
+}
+
 remote="origin"
+help=false
+
+while getopts :r:h flag
+do
+  case "${flag}" in
+    r) remote=${OPTARG};;
+    h) help=true;;
+    *)
+  esac
+done
+
+if [ "$help" = true ]; then
+  usage
+  exit 1
+fi
 
 default_branch=$(git remote show "${remote}" | grep 'HEAD branch' | cut -d' ' -f5)
 
 git fetch "$remote"
 git remote prune "$remote"
-
 git branch -f dependabot-merge "${default_branch}"
 
-git for-each-ref --shell --format="ref=%(refname)" refs/remotes/origin/dependabot | \
+git for-each-ref --shell --format="ref=%(refname)" refs/remotes/$remote/dependabot | \
 while read -r entry
 do
   eval "${entry}"
   ref="${ref:?}"
-  branch="${ref#refs/remotes/origin/}"
+  branch="${ref#refs/remotes/$remote/}"
   echo "Working on ${branch}"
   git checkout "${branch}"
   git rebase dependabot-merge


### PR DESCRIPTION
Add -r option so that we aren't forced to merge against origin

```shell
git dependabot-merge -r github-tkxs
git dependabot-merge -h
```
